### PR TITLE
fix: resolve ESLint dependency conflict causing Netlify build failure

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "@types/react-dom": "18.2.7",
     "@typescript-eslint/eslint-plugin": "7.0.0",
     "@typescript-eslint/parser": "7.0.0",
-    "eslint": "9.24.0",
+    "eslint": "^8.56.0",
     "eslint-config-next": "15.3.0",
     "eslint-plugin-prettier": "5.1.3",
     "eslint-plugin-react-hooks": "4.6.0",


### PR DESCRIPTION
## Problem
The Netlify build was failing due to an ESLint dependency version conflict:
- **Found**: `eslint@9.24.0`
- **Required**: `eslint@"^8.56.0"` from `@typescript-eslint/parser@7.0.0`

## Solution
Downgraded ESLint from `9.24.0` to `^8.56.0` to match the requirements of `@typescript-eslint/parser@7.0.0`.

## Changes Made
- Updated `package.json`: Changed `"eslint": "9.24.0"` to `"eslint": "^8.56.0"`
- This ensures compatibility with the existing TypeScript ESLint configuration

## Why This Approach
Based on research:
- `@typescript-eslint/parser@7.0.0` requires ESLint version `^8.56.0`
- ESLint 9 support is only available in `@typescript-eslint` version 8.0.0+
- Downgrading ESLint is the safest approach to maintain current functionality while resolving the build issue

## Testing
This change should resolve the Netlify build failure and allow successful deployment.

## Future Considerations
To use ESLint 9 in the future, consider upgrading to `@typescript-eslint/parser@8.0.0+` which supports ESLint 9.x.