### PR TITLE
fix: add tailwind-merge & clsx dependencies, clean shadcn config

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,8 @@
     "@astrojs/check": "^0.9.4",
     "@astrojs/tailwind": "^5.1.2",
     "astro": "^4.16.18",
+    "clsx": "^2.1.1",
+    "tailwind-merge": "^2.5.4",
     "tailwindcss": "^3.4.16",
     "typescript": "^5.7.2"
   },

--- a/shadcn.config.ts
+++ b/shadcn.config.ts
@@ -1,5 +1,3 @@
-import type * as components from "./src/components/ui"
-
 export const config = {
   theme: {
     default: "default",


### PR DESCRIPTION
## Fix Netlify Build Failures

This PR resolves the missing dependencies and configuration issues that were causing the Netlify build to fail:

### Issues Fixed:
1. **Missing `tailwind-merge` dependency** - Added to package.json (v2.5.4)
2. **Missing `clsx` dependency** - Added to package.json (v2.1.1)  
3. **Unused import in shadcn.config.ts** - Removed the unused `components` import

### Changes Made:
- ✅ Added `clsx: "^2.1.1"` to dependencies
- ✅ Added `tailwind-merge: "^2.5.4"` to dependencies
- ✅ Removed unused `import type * as components from "./src/components/ui"` from shadcn.config.ts

### Why These Dependencies Are Needed:
The `src/lib/utils.ts` file uses both `clsx` and `tailwind-merge` for the `cn()` utility function that merges Tailwind CSS classes. This is a standard pattern in shadcn/ui components for conditional styling.

### Testing:
These are the exact dependencies required by the existing code. The build should now succeed on Netlify.