### PR TITLE
Fix contact component import path - add missing .astro extension

### DIFF
--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -1,7 +1,7 @@
 ---
 import BaseLayout from '../layouts/BaseLayout.astro';
 import Hero from '../components/Hero.astro';
-import Contact from '../components/ui/contact';
+import Contact from '../components/ui/contact.astro';
 
 const pageTitle = "Contact Lawns All Day - Get Your Free Quote Today";
 const pageDescription = "Contact Lawns All Day for professional lawn care services in Treasure Valley. Call (208) 989-8378 or email info@lawnsallday.com for a free quote.";


### PR DESCRIPTION
## Problem
After restoring the repository to the June 14th state, Netlify is failing to deploy with the error:
```
"Could not resolve '../components/ui/contact' from 'src/pages/contact.astro'"
```

This is the same import issue that was previously fixed in PR #6, where the contact.astro page was trying to import a component without the required .astro file extension.

## Solution
Updated the import statement in `src/pages/contact.astro` from:
```javascript
import Contact from '../components/ui/contact';
```

to:
```javascript
import Contact from '../components/ui/contact.astro';
```

## Testing
- ✅ Verified that the contact component exists at `src/components/ui/contact.astro`
- ✅ Confirmed the import path is correct with the .astro extension
- ✅ This fix follows Astro's requirement for explicit file extensions in imports

## Impact
This resolves the Netlify build failure and allows successful deployment of the restored June 14th codebase.

Fixes the "Could not resolve '../components/ui/contact'" error that was preventing successful deployment.