### PR TITLE
Fix SEO component import paths to resolve Netlify build errors

### DIFF
--- a/src/pages/locations/boise.astro
+++ b/src/pages/locations/boise.astro
@@ -1,8 +1,8 @@
 ---
-import SEO from '../components/SEO.astro';
-import Hero from '../components/Hero.astro';
-import Services from '../components/Services.astro';
-import CTA from '../components/CTA.astro';
+import SEO from '../../components/SEO.astro';
+import Hero from '../../components/Hero.astro';
+import Services from '../../components/Services.astro';
+import CTA from '../../components/CTA.astro';
 
 const schema = {
   '@context': 'https://schema.org',

--- a/src/pages/locations/caldwell.astro
+++ b/src/pages/locations/caldwell.astro
@@ -1,8 +1,8 @@
 ---
-import SEO from '../components/SEO.astro';
-import Hero from '../components/Hero.astro';
-import Services from '../components/Services.astro';
-import CTA from '../components/CTA.astro';
+import SEO from '../../components/SEO.astro';
+import Hero from '../../components/Hero.astro';
+import Services from '../../components/Services.astro';
+import CTA from '../../components/CTA.astro';
 
 const schema = {
   '@context': 'https://schema.org',

--- a/src/pages/locations/eagle.astro
+++ b/src/pages/locations/eagle.astro
@@ -1,8 +1,8 @@
 ---
-import SEO from '../components/SEO.astro';
-import Hero from '../components/Hero.astro';
-import Services from '../components/Services.astro';
-import CTA from '../components/CTA.astro';
+import SEO from '../../components/SEO.astro';
+import Hero from '../../components/Hero.astro';
+import Services from '../../components/Services.astro';
+import CTA from '../../components/CTA.astro';
 
 const schema = {
   '@context': 'https://schema.org',

--- a/src/pages/locations/kuna.astro
+++ b/src/pages/locations/kuna.astro
@@ -1,8 +1,8 @@
 ---
-import SEO from '../components/SEO.astro';
-import Hero from '../components/Hero.astro';
-import Services from '../components/Services.astro';
-import CTA from '../components/CTA.astro';
+import SEO from '../../components/SEO.astro';
+import Hero from '../../components/Hero.astro';
+import Services from '../../components/Services.astro';
+import CTA from '../../components/CTA.astro';
 
 const schema = {
   '@context': 'https://schema.org',

--- a/src/pages/locations/meridian.astro
+++ b/src/pages/locations/meridian.astro
@@ -1,8 +1,8 @@
 ---
-import SEO from '../components/SEO.astro';
-import Hero from '../components/Hero.astro';
-import Services from '../components/Services.astro';
-import CTA from '../components/CTA.astro';
+import SEO from '../../components/SEO.astro';
+import Hero from '../../components/Hero.astro';
+import Services from '../../components/Services.astro';
+import CTA from '../../components/CTA.astro';
 
 const schema = {
   '@context': 'https://schema.org',

--- a/src/pages/locations/nampa.astro
+++ b/src/pages/locations/nampa.astro
@@ -1,8 +1,8 @@
 ---
-import SEO from '../components/SEO.astro';
-import Hero from '../components/Hero.astro';
-import Services from '../components/Services.astro';
-import CTA from '../components/CTA.astro';
+import SEO from '../../components/SEO.astro';
+import Hero from '../../components/Hero.astro';
+import Services from '../../components/Services.astro';
+import CTA from '../../components/CTA.astro';
 
 const schema = {
   '@context': 'https://schema.org',

--- a/src/pages/services/fertilization-and-weed-control.astro
+++ b/src/pages/services/fertilization-and-weed-control.astro
@@ -1,9 +1,9 @@
 ---
-import SEO from '../components/SEO.astro';
-import Hero from '../components/Hero.astro';
-import Services from '../components/Services.astro';
-import CTA from '../components/CTA.astro';
-import Locations from '../components/Locations.astro';
+import SEO from '../../components/SEO.astro';
+import Hero from '../../components/Hero.astro';
+import Services from '../../components/Services.astro';
+import CTA from '../../components/CTA.astro';
+import Locations from '../../components/Locations.astro';
 
 const schema = {
   '@context': 'https://schema.org',

--- a/src/pages/services/lawn-mowing-and-edging.astro
+++ b/src/pages/services/lawn-mowing-and-edging.astro
@@ -1,9 +1,9 @@
 ---
-import SEO from '../components/SEO.astro';
-import Hero from '../components/Hero.astro';
-import Services from '../components/Services.astro';
-import CTA from '../components/CTA.astro';
-import Locations from '../components/Locations.astro';
+import SEO from '../../components/SEO.astro';
+import Hero from '../../components/Hero.astro';
+import Services from '../../components/Services.astro';
+import CTA from '../../components/CTA.astro';
+import Locations from '../../components/Locations.astro';
 
 const schema = {
   '@context': 'https://schema.org',


### PR DESCRIPTION
## Problem
Netlify builds were failing with import path errors like:
```
"Could not resolve '../components/SEO.astro' from 'src/pages/locations/boise.astro'"
```

## Root Cause
Files in subdirectories (`src/pages/locations/` and `src/pages/services/`) were using incorrect relative import paths. They were using `'../components/SEO.astro'` when they should use `'../../components/SEO.astro'` since they need to go up two directory levels to reach the components folder.

## Solution
Updated import paths in all affected files:

### Location Pages Fixed:
- `src/pages/locations/boise.astro`
- `src/pages/locations/kuna.astro` 
- `src/pages/locations/eagle.astro`
- `src/pages/locations/nampa.astro`
- `src/pages/locations/caldwell.astro`
- `src/pages/locations/meridian.astro`

### Service Pages Fixed:
- `src/pages/services/lawn-mowing-and-edging.astro`
- `src/pages/services/fertilization-and-weed-control.astro`

### Changes Made:
- Changed `'../components/SEO.astro'` → `'../../components/SEO.astro'`
- Changed `'../components/Hero.astro'` → `'../../components/Hero.astro'`
- Changed `'../components/Services.astro'` → `'../../components/Services.astro'`
- Changed `'../components/CTA.astro'` → `'../../components/CTA.astro'`
- Changed `'../components/Locations.astro'` → `'../../components/Locations.astro'`

## Testing
- ✅ All import paths now correctly resolve to `src/components/` directory
- ✅ Layout files (`src/layouts/Layout.astro` and `src/layouts/BaseLayout.astro`) were already correct and left unchanged
- ✅ This should resolve the Netlify build error

## Impact
This fix resolves the systematic import path issues that were causing Netlify deployment failures. All location and service pages should now build successfully.